### PR TITLE
Update cropping tool layout and add rotation

### DIFF
--- a/zuschnitt-openai.html
+++ b/zuschnitt-openai.html
@@ -6,9 +6,10 @@
   <title>21:9 Bildzuschnitt</title>
   <style>
     body { margin: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; background: #f0f0f0; font-family: sans-serif; }
-    #container { position: relative; width: 80vw; max-width: 1200px; aspect-ratio: 21/9; background: #ddd; overflow: hidden; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.2); cursor: grab; }
+    #container { position: relative; width: 2000px; height: 857px; background: #ddd; overflow: hidden; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.2); cursor: grab; }
     #container.dragging { cursor: grabbing; }
     canvas { display: block; user-select: none; pointer-events: none; }
+    #placeholder { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: #666; font-size: 1.2rem; pointer-events: none; text-align: center; }
     #controls { margin-top: 1rem; display: flex; gap: 1rem; }
     button { padding: 0.5rem 1rem; border: none; border-radius: 4px; background: #007acc; color: white; font-size: 1rem; cursor: pointer; transition: background 0.2s; }
     button:hover { background: #005fa3; }
@@ -18,10 +19,12 @@
 <body>
   <div id="container" tabindex="0">
     <canvas id="canvas"></canvas>
+    <div id="placeholder">Bild hier einfügen, ablegen oder laden</div>
   </div>
   <div id="controls">
     <button id="loadBtn">Bild laden</button>
     <button id="saveBtn" disabled>Speichern</button>
+    <label>Rotation: <input type="range" id="rotateRange" min="-45" max="45" value="0"></label>
   </div>
   <input type="file" id="fileInput" accept="image/*" />
 
@@ -32,7 +35,9 @@
     const fileInput = document.getElementById('fileInput');
     const loadBtn = document.getElementById('loadBtn');
     const saveBtn = document.getElementById('saveBtn');
-    let img = new Image(), scale = 1, minScale = 1, offsetX = 0, offsetY = 0;
+    const rotateRange = document.getElementById('rotateRange');
+    const placeholder = document.getElementById('placeholder');
+    let img = new Image(), scale = 1, minScale = 1, offsetX = 0, offsetY = 0, rotation = 0;
     let isDragging = false, startX = 0, startY = 0, filename = '';
 
     function resizeCanvas() {
@@ -59,17 +64,31 @@
         offsetX = (canvas.width - img.width*scale)/2;
         offsetY = (canvas.height - img.height*scale)/2;
         draw(); saveBtn.disabled = false;
+        placeholder.style.display = 'none';
       };
       img.src = src;
       filename = name.replace(/\.[^/.]+$/, '');
     }
     function draw() {
       ctx.clearRect(0,0,canvas.width,canvas.height);
-      if(img.src) ctx.drawImage(img, offsetX, offsetY, img.width*scale, img.height*scale);
+      if(img.src) {
+        ctx.save();
+        ctx.translate(offsetX + img.width*scale/2, offsetY + img.height*scale/2);
+        ctx.rotate(rotation);
+        ctx.drawImage(img, -img.width*scale/2, -img.height*scale/2, img.width*scale, img.height*scale);
+        ctx.restore();
+        placeholder.style.display = 'none';
+      } else {
+        placeholder.style.display = 'flex';
+      }
     }
 
     loadBtn.addEventListener('click', () => fileInput.click());
     fileInput.addEventListener('change', () => loadImageFile(fileInput.files[0]));
+    rotateRange.addEventListener('input', () => {
+      rotation = parseFloat(rotateRange.value) * Math.PI / 180;
+      draw();
+    });
 
     container.addEventListener('dragover', e => { e.preventDefault(); container.classList.add('dragging'); });
     container.addEventListener('dragleave', () => container.classList.remove('dragging'));
@@ -135,7 +154,10 @@
 
     saveBtn.addEventListener('click', ()=>{
       const out=document.createElement('canvas'); out.width=canvas.width; out.height=canvas.height;
-      const octx=out.getContext('2d'); octx.drawImage(img, offsetX, offsetY, img.width*scale, img.height*scale);
+      const octx=out.getContext('2d');
+      octx.translate(offsetX + img.width*scale/2, offsetY + img.height*scale/2);
+      octx.rotate(rotation);
+      octx.drawImage(img, -img.width*scale/2, -img.height*scale/2, img.width*scale, img.height*scale);
       out.toBlob(blob=>{
         const link=document.createElement('a');
         link.download=filename+'_zuschnitt.jpg';


### PR DESCRIPTION
## Summary
- fix container size to 2000x857 px
- add placeholder instructions
- add rotation slider to rotate image up to ±45°
- implement rotation in preview and saved output

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684895e55bb883258b1c6cbd169730b3